### PR TITLE
Make sure overlapping interface is created after nodes are loaded

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -13,11 +13,7 @@ exports.sourceNodes = async (gatsby, pluginOptions) => {
     options,
   }
 
-  return loadUmbracoNodes(helpers)
-}
-
-exports.createSchemaCustomization = async (gatsby, pluginOptions) => {
-  const options = await validateAndPrepOptions(pluginOptions, gatsby.reporter)
+  await loadUmbracoNodes(helpers)
   createAndRegisterCommonInterface(gatsby, options)
 }
 

--- a/lib/create-common-interface.js
+++ b/lib/create-common-interface.js
@@ -1,12 +1,14 @@
 const { allTypes } = require("./typeRegistry")
+const formatMessage = require("../util/formatMessage")
 
 module.exports = (gatsby, options) => {
   const { name: interface, fields } = options.commonInterface
+  gatsby.reporter.verbose(formatMessage(`Creating common interface "${interface}"`))
   const interfaceType = createInterfaceTypeDefinition(interface, fields)
-  const concreteTypes = allTypes().map(type =>
-    buildObjectTypeWithInterface(type, interface, gatsby.schema)
-  )
-
+  const concreteTypes = allTypes().map(type => {
+    gatsby.reporter.verbose(formatMessage(`Adding interface to type "${type}"`))
+    return buildObjectTypeWithInterface(type, interface, gatsby.schema)
+  })
   gatsby.actions.createTypes([interfaceType, ...concreteTypes])
 }
 


### PR DESCRIPTION
The order in which `sourceNodes` and `createSchemaCustomization` are executed seems to vary between Gatsby versions. There is no way for a plugin to control this. The plugin relies on this order, the nodes need to be loaded _before_ the interface is created, else it has no clue what types exist.

This PR makes sure that these two steps are executed in the correct order by moving the code from `createSchemaCustomization` into `sourceNodes`.

Closes #11 